### PR TITLE
Fix deep leaks in `RetiredPtr`

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -199,7 +199,7 @@ impl<T: 'static> Drop for HzrdCell<T> {
                 Err(_) => false,
             }
         };
-        
+
         // SAFETY: Important that all references to inner are dropped before this
         if should_drop_inner {
             // SAFETY:

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -8,13 +8,13 @@ Holds a value that can be shared, and mutated, across multiple threads
 
 See the [crate-level documentation](crate) for more details.
 */
-pub struct HzrdCell<T> {
+pub struct HzrdCell<T: 'static> {
     value: NonNull<HzrdValue<T, SharedDomain>>,
     hzrd_ptr: NonNull<HzrdPtr>,
 }
 
 // Private methods
-impl<T> HzrdCell<T> {
+impl<T: 'static> HzrdCell<T> {
     fn value(&self) -> &HzrdValue<T, SharedDomain> {
         // SAFETY: Only shared references to this are allowed
         unsafe { self.value.as_ref() }
@@ -26,7 +26,7 @@ impl<T> HzrdCell<T> {
     }
 }
 
-impl<T> HzrdCell<T> {
+impl<T: 'static> HzrdCell<T> {
     /**
     Construct a new [`HzrdCell`] with the given value
     The value will be allocated on the heap seperate of the metadata associated with the [`HzrdCell`].
@@ -155,7 +155,7 @@ impl<T> HzrdCell<T> {
 unsafe impl<T: Send + Sync> Send for HzrdCell<T> {}
 unsafe impl<T: Send + Sync> Sync for HzrdCell<T> {}
 
-impl<T> Clone for HzrdCell<T> {
+impl<T: 'static> Clone for HzrdCell<T> {
     fn clone(&self) -> Self {
         let hzrd_ptr = self.value().hzrd_ptr();
 
@@ -166,7 +166,7 @@ impl<T> Clone for HzrdCell<T> {
     }
 }
 
-impl<T> From<Box<T>> for HzrdCell<T> {
+impl<T: 'static> From<Box<T>> for HzrdCell<T> {
     fn from(boxed: Box<T>) -> Self {
         let domain = SharedDomain::new();
         let value = HzrdValue::new_in(boxed, domain);
@@ -179,7 +179,7 @@ impl<T> From<Box<T>> for HzrdCell<T> {
     }
 }
 
-impl<T> Drop for HzrdCell<T> {
+impl<T: 'static> Drop for HzrdCell<T> {
     fn drop(&mut self) {
         // SAFETY: The HzrdPtr is exclusively owned by the current cell
         unsafe { self.hzrd_ptr().free() };

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
-use std::ops::Deref;
 use std::any::Any;
+use std::ops::Deref;
 use std::ptr::{addr_of, NonNull};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering::*};

--- a/src/core.rs
+++ b/src/core.rs
@@ -416,4 +416,14 @@ mod tests {
         drop(_handle_1);
         unsafe { hzrd_ptr_1.as_ref().free() };
     }
+
+    #[test]
+    fn deep_leak() {
+        let object = vec![String::from("Hello"), String::from("World")];
+        let ptr = NonNull::from(Box::leak(Box::new(object)));
+
+        // SAFETY: ptr is heap-allocated
+        let retired = unsafe { RetiredPtr::new(ptr) };
+        drop(retired);
+    }
 }

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -89,7 +89,7 @@ pub struct HzrdWriter<T> {
     value: Box<HzrdValue<T, UnsafeDomain>>,
 }
 
-impl<T> HzrdWriter<T> {
+impl<T: 'static> HzrdWriter<T> {
     /**
     Construct a new [`HzrdWriter`] containing the given value.
     The value will be allocated on the heap seperate of the metadata associated with the [`HzrdWriter`].
@@ -144,7 +144,7 @@ impl<T> HzrdWriter<T> {
     }
 }
 
-impl<T> From<Box<T>> for HzrdWriter<T> {
+impl<T: 'static> From<Box<T>> for HzrdWriter<T> {
     fn from(boxed: Box<T>) -> Self {
         let domain = unsafe { UnsafeDomain::new() };
         let value = Box::new(HzrdValue::new_in(boxed, domain));
@@ -165,7 +165,7 @@ pub struct HzrdReader<'writer, T> {
     hzrd_ptr: NonNull<HzrdPtr>,
 }
 
-impl<T> HzrdReader<'_, T> {
+impl<T: 'static> HzrdReader<'_, T> {
     /**
     Construct a reader for the value contained by the given writer
     */


### PR DESCRIPTION
Use trait objects for RetiredPtr to call drop implementation on type-erased object