### PR TITLE
Fix memory ordering

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,8 @@
 use std::any::Any;
 use std::ptr::{addr_of, NonNull};
 use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::*;
 use std::sync::Arc;
 
 // -------------------------------------
@@ -79,12 +80,12 @@ impl HzrdPtr {
 
     /// Get the value held by the hazard pointer
     pub fn get(&self) -> usize {
-        self.0.load(SeqCst)
+        self.0.load(Acquire)
     }
 
     /// Try to aquire the hazard pointer
     pub fn try_acquire(&self) -> Option<&Self> {
-        match self.0.compare_exchange(0, dummy_addr(), SeqCst, SeqCst) {
+        match self.0.compare_exchange(0, dummy_addr(), Relaxed, Relaxed) {
             Ok(_) => Some(self),
             Err(_) => None,
         }
@@ -98,7 +99,7 @@ impl HzrdPtr {
     - The caller must assert that the ptr did not change before the value was stored
     */
     pub unsafe fn protect<T>(&self, ptr: *mut T) {
-        self.0.store(ptr as usize, SeqCst);
+        self.0.store(ptr as usize, Release);
     }
 
     /**
@@ -108,7 +109,7 @@ impl HzrdPtr {
     - The caller must be the current "owner" of the hazard pointer
     */
     pub unsafe fn reset(&self) {
-        self.0.store(dummy_addr(), SeqCst);
+        self.0.store(dummy_addr(), Release);
     }
 
     /**
@@ -119,7 +120,7 @@ impl HzrdPtr {
     - The hazard cell must be reaquired after calling this using [`try_acquire`](`HzrdPtr::try_acquire`)
     */
     pub unsafe fn release(&self) {
-        self.0.store(0, SeqCst);
+        self.0.store(0, Release);
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -132,7 +132,7 @@ impl Default for HzrdPtr {
 
 impl std::fmt::Debug for HzrdPtr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "HzrdPtr({:#x})", self.0.load(SeqCst))
+        write!(f, "HzrdPtr({:#x})", self.0.load(Relaxed))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ mod private {
 
 use std::ops::Deref;
 use std::ptr::NonNull;
-use std::sync::atomic::{AtomicPtr, Ordering::SeqCst};
+use std::sync::atomic::{AtomicPtr, Ordering::*};
 
 use crate::core::{Domain, HzrdPtr, RetiredPtr};
 
@@ -367,7 +367,7 @@ impl<'hzrd, T> ReadHandle<'hzrd, T> {
             unsafe { hzrd_ptr.protect(ptr) };
 
             // We now need to keep updating it until it is in a consistent state
-            let new_ptr = value.load(SeqCst);
+            let new_ptr = value.load(Acquire);
             if ptr == new_ptr {
                 break;
             } else {


### PR DESCRIPTION
The rework used memory ordering `SeqCst` everywhere to fix a data race that was encountered. This relaxes some of the memory ordering, although there is still some `SeqCst` in use.