### PR TITLE
Add caching for hazard pointers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ path = "benchmarks/back-and-forth.rs"
 [[bin]]
 name = "local-writer"
 path = "benchmarks/local-writer.rs"
+
+[[bin]]
+name = "single-threaded"
+path = "benchmarks/single-threaded.rs"

--- a/benchmarks/single-threaded.rs
+++ b/benchmarks/single-threaded.rs
@@ -1,0 +1,10 @@
+use hzrd::HzrdCell;
+
+fn main() {
+    let cell = HzrdCell::new(0);
+
+    for i in 0..1_000_000 {
+        let _handle = cell.get();
+        cell.set(i)
+    }
+}

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -29,7 +29,7 @@ pub struct HzrdPtrsCache(Vec<usize>);
 
 impl HzrdPtrsCache {
     fn load<'t>(hzrd_ptrs: impl Iterator<Item = &'t HzrdPtr>) -> Self {
-        let mut hzrd_ptrs_cache = HAZARD_POINTERS_CACHE.with(|cell| cell.take());
+        let mut hzrd_ptrs_cache = HAZARD_POINTERS_CACHE.take();
         hzrd_ptrs_cache.clear();
         hzrd_ptrs_cache.extend(hzrd_ptrs.map(HzrdPtr::get));
         Self(hzrd_ptrs_cache)
@@ -43,7 +43,7 @@ impl HzrdPtrsCache {
 impl Drop for HzrdPtrsCache {
     fn drop(&mut self) {
         let hzrd_ptrs = std::mem::take(&mut self.0);
-        HAZARD_POINTERS_CACHE.with(|cell| cell.replace(hzrd_ptrs));
+        HAZARD_POINTERS_CACHE.replace(hzrd_ptrs);
     }
 }
 

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -7,6 +7,20 @@ use crate::stack::SharedStack;
 
 // -------------------------------------
 
+/*
+# Todo:
+- Add options for caching:
+  -> No caching
+  -> Maximum size of cache?
+  -> Fixed size for cache?
+  -> Pre-allocated cache?
+- Add option for bulk-reclaim (default to what?), use const generics?
+- Test HashSet for cache (BTreeSet can't reuse allocation?)
+
+*/
+
+// -------------------------------------
+
 thread_local! {
     static HAZARD_POINTERS_CACHE: Cell<Vec<usize>> = const { Cell::new(Vec::new()) };
 }

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -29,7 +29,7 @@ pub struct HzrdPtrsCache(Vec<usize>);
 
 impl HzrdPtrsCache {
     fn load<'t>(hzrd_ptrs: impl Iterator<Item = &'t HzrdPtr>) -> Self {
-        let mut hzrd_ptrs_cache = HAZARD_POINTERS_CACHE.take();
+        let mut hzrd_ptrs_cache = HAZARD_POINTERS_CACHE.with(|cell| cell.take());
         hzrd_ptrs_cache.clear();
         hzrd_ptrs_cache.extend(hzrd_ptrs.map(HzrdPtr::get));
         Self(hzrd_ptrs_cache)
@@ -43,7 +43,7 @@ impl HzrdPtrsCache {
 impl Drop for HzrdPtrsCache {
     fn drop(&mut self) {
         let hzrd_ptrs = std::mem::take(&mut self.0);
-        HAZARD_POINTERS_CACHE.replace(hzrd_ptrs);
+        HAZARD_POINTERS_CACHE.with(|cell| cell.replace(hzrd_ptrs));
     }
 }
 


### PR DESCRIPTION
The cache is used when loading the entire list of hazard pointers in a given domain. This is done when reclaiming memory in order to avoid multiple loads for each retired-pointer processed.