### PR TITLE
Lock-free retired ptrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # hzrd
 Provides shared, mutable state by utilizing hazard pointers.
 
-The core concept of the crate is to trade memory for speed. The containers avoid locking the value, and instead accumulate garbage: Excess data that will need to be freed at a later point. The garbage collection is controlled using hazard pointers. Each reader of the value can hold one reference to the value. If the value of the container is swapped, then the reference they hold is kept valid through their hazard pointer. They can then (at some later point) drop the reference, and the value will be cleaned up _at some point_. The core API in the crate is the HzrdCell.
-
 ## HzrdCell
 
-HzrdCell aims to provide something akin to a multithreaded version of std's Cell-type. A basic example:
+The core API of this crate is the HzrdCell, which provides an API reminiscent to that of the standard library's Cell-type. However, HzrdCell allows shared mutation across multiple threads.
 
 ```rust
 use hzrd::HzrdCell;
@@ -14,12 +12,12 @@ let cell = HzrdCell::new(false);
 
 std::thread::scope(|s| {
     s.spawn(|| {
-        // Loop until the value is true
+        // Loop until the value is true ...
         while !cell.get() {
             std::hint::spin_loop();
         }
 
-        // And then set it back to false!
+        // ... and then set it back to false!
         cell.set(false);
     });
 
@@ -33,5 +31,3 @@ std::thread::scope(|s| {
     });
 });
 ```
-
-HzrdCell provides memory safe, multithreaded, shared mutability. But this isn't all that useful. We often want some sort of synchronization to avoid races (not data races, just general races).

--- a/src/core.rs
+++ b/src/core.rs
@@ -116,6 +116,7 @@ impl<'hzrd, T> ReadHandle<'hzrd, T> {
                 ptr = new_ptr;
             }
         }
+        std::sync::atomic::fence(SeqCst);
 
         // SAFETY: This pointer is now held valid by the hazard pointer
         let value = unsafe { &*ptr };

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -23,7 +23,7 @@ use crate::stack::SharedStack;
 /**
 This variable can be used to configure the behavior of the domains provided by this crate
 
-The variable can only be set once, and this must happen before any operation on any of the domains. If the variable has not been configured before the first access then the default value is used (see [`Config::default`]). The variable uses a standard [`OnceLock`](`std::sync::OnceLock`), and can be used as such:
+The variable can only be set once, and this must happen before any operation on any of the domains. If the variable has not been configured before the first access, then the default value is used instead (see [`Config::default`]). The variable uses a standard [`OnceLock`](`std::sync::OnceLock`), and can be used as such:
 ```
 # use hzrd::domains::{Config, GLOBAL_CONFIG};
 let config = Config::default().caching(true);
@@ -61,7 +61,7 @@ impl Config {
     /**
     Set bulk size (default: `1`)
 
-    The bulk size is the smallest amount of elements in a list of retired pointers that will cause memory reclamation to occur. Example: If the bulk size is `4`, then a call to `reclaim` will be a no-op until there is atleast `4` retired objects.
+    The bulk size is the smallest amount of elements in a list of retired pointers that will cause memory reclamation to occur. For example, if the bulk size is `4`, then a call to `reclaim` will be a no-op unless there are atleast `4` retired objects.
 
     # Example
     ```
@@ -167,7 +167,7 @@ static GLOBAL_DOMAIN: SharedDomain = SharedDomain::new();
 /**
 A globally shared, multithreaded domain
 
-This is the default domain used by `HzrdCell`, and is the recommended domain for most applications. It's based on a 'globally shared, static variable, and so there is no "constructor" for this domain. The [`GlobalDomain`] struct is  a Zero Sized Type (ZST) that acts simply as an accessor to this globally shared variable.
+This is the default domain used by `HzrdCell`, and is the recommended domain for most applications. It's based on a globally shared, static variable, and so there is no "constructor" for this domain. The [`GlobalDomain`] struct is a Zero Sized Type (ZST) that acts simply as an accessor to this globally shared variable.
 
 # Example
 ```


### PR DESCRIPTION
Swap out implementation using `Mutex<Vec<_>>` for a lock-free linked list.